### PR TITLE
Foreground service notification

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Cordova plugin for Radar, location data infrastructure",
   "homepage": "https://www.radar.io",
   "license": "Apache-2.0",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "main": "www/Radar.js",
   "devDependencies": {
     "babel-eslint": "^7.1.1",

--- a/src/android/src/main/java/io/radar/cordova/RadarCordovaPlugin.java
+++ b/src/android/src/main/java/io/radar/cordova/RadarCordovaPlugin.java
@@ -821,7 +821,8 @@ public class RadarCordovaPlugin extends CordovaPlugin {
                 .putExtra("text", args.getString(1))
                 .putExtra("icon", args.getString(2))
                 .putExtra("importance", args.getString(3))
-                .putExtra("id", args.getString(4));
+                .putExtra("id", args.getString(4))
+                .putExtra("activity", activity.getClass().getCanonicalName());
             activity.getApplicationContext().startForegroundService(intent);
             callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK));
         }

--- a/src/android/src/main/java/io/radar/cordova/RadarForegroundService.java
+++ b/src/android/src/main/java/io/radar/cordova/RadarForegroundService.java
@@ -2,6 +2,7 @@ package io.radar.cordova;
 
 import android.content.Intent;
 import android.content.Context;
+import android.app.PendingIntent;
 import android.app.Service;
 import android.app.Notification;
 import android.app.NotificationChannel;
@@ -54,11 +55,22 @@ public class RadarForegroundService extends Service {
 
         int icon = getResources().getIdentifier((String) extras.get("icon"), "drawable", context.getPackageName());
 
+        PendingIntent pendingIntent;
+        try {
+            Class activityClass = Class.forName((String) extras.get("activity"));
+            Intent intent = new Intent(this, activityClass);
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+            pendingIntent = PendingIntent.getActivity(this, 0, intent, 0);
+        } catch (ClassNotFoundException e) {
+            pendingIntent = null;
+        }
+
         Notification notification = new Notification.Builder(context, "location")
             .setContentTitle((CharSequence) extras.get("title"))
             .setContentText((CharSequence) extras.get("text"))
             .setOngoing(true)
-            .setSmallIcon(icon != 0 ? icon: 17301575)
+            .setSmallIcon(icon != 0 ? icon : 17301546) // r_drawable_ic_dialog_map
+            .setContentIntent(pendingIntent)
             .build();
 
         Integer id;

--- a/src/android/src/main/java/io/radar/cordova/RadarForegroundService.java
+++ b/src/android/src/main/java/io/radar/cordova/RadarForegroundService.java
@@ -52,10 +52,13 @@ public class RadarForegroundService extends Service {
         NotificationChannel channel = new NotificationChannel("location", "Location", importance);
         getSystemService(NotificationManager.class).createNotificationChannel(channel);
 
+        int icon = getResources().getIdentifier((String) extras.get("icon"), "drawable", context.getPackageName());
+
         Notification notification = new Notification.Builder(context, "location")
             .setContentTitle((CharSequence) extras.get("title"))
             .setContentText((CharSequence) extras.get("text"))
             .setOngoing(true)
+            .setSmallIcon(icon != 0 ? icon: 17301575)
             .build();
 
         Integer id;
@@ -65,7 +68,7 @@ public class RadarForegroundService extends Service {
             id = 0;
         }
 
-        startForeground(id != 0 ? id : 197812504, notification);
+        startForeground(id != 0 ? id : 20160525, notification);
     }
 
     @Override


### PR DESCRIPTION
- pass `icon` to avoid showing default notification
- pass Cordova main activity to `contentIntent` so that tapping notification opens app

Example:

```
cordova.plugins.radar.startForegroundService({
  title: 'Foo',
  text: 'Bar'
});
```

![image](https://user-images.githubusercontent.com/245210/95785482-d6ed2380-0ca3-11eb-85f4-31cb4e552d93.png)