### PR TITLE
Handle null tripOptions in getTripOptions()

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Cordova plugin for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://www.radar.io",
   "license": "Apache-2.0",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "main": "www/Radar.js",
   "devDependencies": {
     "babel-eslint": "^7.1.1",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
         id="cordova-plugin-radar"
-        version="3.1.2">
+        version="3.1.3">
     <name>Radar</name>
     <js-module src="www/Radar.js" name="Radar">
         <clobbers target="cordova.plugins.radar"/>

--- a/src/android/src/main/java/io/radar/cordova/RadarCordovaPlugin.java
+++ b/src/android/src/main/java/io/radar/cordova/RadarCordovaPlugin.java
@@ -467,11 +467,16 @@ public class RadarCordovaPlugin extends CordovaPlugin {
 
     public void getTripOptions(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
         RadarTripOptions options = Radar.getTripOptions();
-        JSONObject optionsObj = null;
-        if (options != null) {
-            optionsObj = options.toJson(); 
+
+        if (options == null) {
+            String optionsStr = null;
+            PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, optionsStr);
+            callbackContext.sendPluginResult(pluginResult);
+
+            return;
         }
 
+        JSONObject optionsObj = options.toJson();
         PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, optionsObj);
         callbackContext.sendPluginResult(pluginResult);
     }

--- a/src/ios/CDVRadar.m
+++ b/src/ios/CDVRadar.m
@@ -316,11 +316,16 @@
 
 - (void)getTripOptions:(CDVInvokedUrlCommand *)command {
     RadarTripOptions *options = [Radar getTripOptions];
-    NSDictionary *optionsDict;
-    if (options) {
-      optionsDict = [options dictionaryValue];
+
+    if (options == nil) {
+        NSString *optionsStr = nil;
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:optionsStr];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+
+        return;
     }
 
+    NSDictionary *optionsDict = [options dictionaryValue];
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:optionsDict];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }


### PR DESCRIPTION
`PluginResult(Status status, JSONObject message)` doesn't handle `message = null`, so we have to use `PluginResult(Status status, String message)` instead https://github.com/apache/cordova-android/blob/master/framework/src/org/apache/cordova/PluginResult.java#L52

Also changed on iOS for consistency