### PR TITLE
[9522] Add workflow to automate SDK version bumps

### DIFF
--- a/.github/workflows/update-native-sdks.yml
+++ b/.github/workflows/update-native-sdks.yml
@@ -1,0 +1,69 @@
+# Bump Native SDK version numbers whenever a repository dispatch of a release
+# is received
+name: Bump Native SDKs
+on:
+  repository_dispatch:
+    types: ['ios-sdk-release', 'android-sdk-release']
+jobs:
+  update_android_sdk_version:
+    runs-on: ubuntu-latest
+    if: github.event.client_payload.platform == "android"
+    steps:
+      - name: Event Information
+        run: echo ${{ github.event.client_payload.release }}
+
+      # checkout the repo
+      - uses: actions/checkout@v2
+
+      # copy the template file to its final destination
+      - name: Copy plugin.xml template file
+        uses: canastro/copy-action@master
+        with:
+          source: "plugin.xml.template"
+          target: "plugin.xml"
+
+      # render the template using the input sdk version
+      - name: Render radar-sdk-android release version onto plugin.xml
+        uses: jayamanikharyono/jinja-action@v0.1
+        with:
+          data: version=${{ github.event.client_payload.release }}
+          path: "plugin.xml"
+
+      # open a pull request with the new sdk version
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: Automated radar-sdk-android version bump to ${{ github.event.client_payload.release }}
+          reviewers: radarlabs/eng
+          token: ${{ secrets.GITHUB_TOKEN }}
+  update_ios_sdk_version:
+    runs-on: ubuntu-latest
+    if: github.event.client_payload.platform == 'ios'
+    steps:
+      - name: Event Information
+        run: echo ${{ github.event.client_payload.release }}
+
+      # checkout the repo
+      - uses: actions/checkout@v2
+
+      # copy the template file to its final destination
+      - name: Copy plugin.xml template file
+        uses: canastro/copy-action@master
+        with:
+          source: "plugin.xml.template"
+          target: "plugin.xml"
+
+      # render the template using the input sdk version
+      - name: Render radar-sdk-ios release version onto plugin.xml
+        uses: jayamanikharyono/jinja-action@v0.1
+        with:
+          data: version=${{ github.event.client_payload.release }}
+          path: "plugin.xml"
+
+      # open a pull request with the new sdk version
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: Automated radar-sdk-ios version bump to ${{ github.event.client_payload.release }}
+          reviewers: radarlabs/eng
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/plugin.xml.template
+++ b/plugin.xml.template
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
+        id="cordova-plugin-radar"
+        version="{{ version }}">
+    <name>Radar</name>
+    <js-module src="www/Radar.js" name="Radar">
+        <clobbers target="cordova.plugins.radar"/>
+    </js-module>
+    <platform name="android">
+        <config-file target="res/xml/config.xml" parent="/*">
+            <feature name="Radar">
+                <param name="android-package" value="io.radar.cordova.RadarCordovaPlugin"/>
+            </feature>
+        </config-file>
+        <config-file target="AndroidManifest.xml" parent="/manifest/application">
+            <service android:name="io.radar.cordova.RadarForegroundService" android:foregroundServiceType="location" android:stopWithTask="true" />
+        </config-file>
+        <config-file target="AndroidManifest.xml" parent="/manifest/application">
+            <receiver
+                    android:name="io.radar.cordova.RadarCordovaPlugin$RadarCordovaReceiver"
+                    android:enabled="true"
+                    android:exported="false">
+                <intent-filter>
+                    <action android:name="io.radar.sdk.RECEIVED" />
+                </intent-filter>
+            </receiver>
+        </config-file>
+
+        <edit-config file="AndroidManifest.xml" target="/manifest" mode="merge">
+            <manifest xmlns:tools="http://schemas.android.com/tools" />
+        </edit-config>
+
+        <config-file target="AndroidManifest.xml" parent="/*">
+            <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" tools:node="remove" />
+        </config-file>
+
+        <config-file target="AndroidManifest.xml" parent="/*">
+            <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+        </config-file>
+
+        <source-file src="src/android/src/main/java/io/radar/cordova/RadarCordovaPlugin.java" target-dir="src/android/src/main/java/io/radar/cordova"/>
+        <source-file src="src/android/src/main/java/io/radar/cordova/RadarForegroundService.java" target-dir="src/android/src/main/java/io/radar/cordova"/>
+
+        <framework src="io.radar:sdk:{{ version }}"/>
+
+    </platform>
+    <platform name="ios">
+        <config-file target="config.xml" parent="/*">
+            <feature name="Radar">
+                <param name="ios-package" value="CDVRadar"/>
+                <param name="onload" value="true" />
+            </feature>
+        </config-file>
+
+        <preference name="NS_LOCATION_WHEN_IN_USE_USAGE_DESCRIPTION" default="This app uses your location for geofencing." />
+        <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
+            <string>$NS_LOCATION_WHEN_IN_USE_USAGE_DESCRIPTION</string>
+        </config-file>
+
+        <preference name="NS_LOCATION_ALWAYS_AND_WHEN_IN_USE_USAGE_DESCRIPTION" default="This app uses your location for geofencing." />
+        <config-file target="*-Info.plist" parent="NSLocationAlwaysAndWhenInUseUsageDescription">
+            <string>$NS_LOCATION_ALWAYS_AND_WHEN_IN_USE_USAGE_DESCRIPTION</string>
+        </config-file>
+
+        <preference name="NS_LOCATION_ALWAYS_USAGE_DESCRIPTION" default="This app uses your location for geofencing." />
+        <config-file target="*-Info.plist" parent="NSLocationAlwaysUsageDescription">
+            <string>$NS_LOCATION_ALWAYS_USAGE_DESCRIPTION</string>
+        </config-file>
+
+        <header-file src="src/ios/CDVRadar.h"/>
+        <source-file src="src/ios/CDVRadar.m"/>
+        <framework src="RadarSDK" type="podspec" spec="{{ version }}"/>
+    </platform>
+</plugin>


### PR DESCRIPTION
## Summary
Added a workflow that bumps the version whenever the repo receives a repository_dispatch github event from our native SDKs: [Android SDK](https://github.com/radarlabs/radar-sdk-android) or [iOS SDK](https://github.com/radarlabs/radar-sdk-ios).

It'll update `plugin.xml` based off a template file

Note: Decided to keep things simple and just update the version for now. Can revisit a better way to automate this in the future. Some ideas: (a) version no. caching, (b) adding both versions to payload, (c) more clever stitching of the `plugin.xml` file