### PR TITLE
Installing the Radar Cordova SDK results in the app's Podfile being overwritten

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run: cd plugin && npm install
       - run: cd plugin && sudo npm install -g cordova
       - run: cd example && npm install
-      - run: sudo chown -R 502:20 "/Users/distiller/cordova-plugin-radar/plugin/.config"
+      # - run: sudo chown -R 502:20 "/Users/distiller/.config"
       - run: cd example && cordova platform add ios
       - run: cd example && cordova plugin add ../plugin
       - run: cd example && cordova build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run: cd plugin && npm install
       - run: cd plugin && sudo npm install -g cordova
       - run: cd example && npm install
-      - run: sudo chown -R 502:20 "/Users/distiller/.config"
+      - run: sudo chown -R 502:20 "/Users/distiller/cordova-plugin-radar/.config"
       - run: cd example && cordova platform add ios
       - run: cd example && cordova plugin add ../plugin
       - run: cd example && cordova build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - run: cd example && cordova build
   ios:
     macos:
-      xcode: 13.1.0
+      xcode: 13.4.1
     working_directory: ~/cordova-plugin-radar
     steps:
       - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run: cd plugin && npm install
       - run: cd plugin && sudo npm install -g cordova
       - run: cd example && npm install
-      - run: sudo chown -R 502:20 "/Users/distiller/cordova-plugin-radar/.config"
+      - run: sudo chown -R 502:20 "/Users/distiller/cordova-plugin-radar/plugin/.config"
       - run: cd example && cordova platform add ios
       - run: cd example && cordova plugin add ../plugin
       - run: cd example && cordova build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,8 @@ jobs:
     steps:
       - checkout:
           path: ~/cordova-plugin-radar
-      - run: npm install
-      - run: sudo npm install -g cordova
+      - run: cd plugin && npm install
+      - run: cd plugin && sudo npm install -g cordova
       - run: cd example && npm install
       - run: sudo chown -R 502:20 "/Users/distiller/.config"
       - run: cd example && cordova platform add ios

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@radarlabs/cordova-plugin-radar": "file:../plugin",
         "cordova-android": "^11.0.0",
-        "cordova-ios": "^6.2.0"
+        "cordova-ios": "^6.3.0"
       }
     },
     "../plugin": {
@@ -253,9 +253,10 @@
       }
     },
     "node_modules/cordova-ios": {
-      "version": "6.2.0",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/cordova-ios/-/cordova-ios-6.3.0.tgz",
+      "integrity": "sha512-BZybgFzc7D0HmhkTYurFrRXiWgvYohmT7bwQsLPhf+VdiDjwGXbiSWgg3uP9MChvacCNcGXXUl2NhOaNC9UVaA==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "cordova-common": "^4.0.2",
         "fs-extra": "^9.1.0",

--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,11 @@
   "cordova": {
     "plugins": {
       "@radarlabs/cordova-plugin-radar": {},
-      "cordova-plugin-radar": {}
+      "cordova-plugin-radar": {
+        "NS_LOCATION_WHEN_IN_USE_USAGE_DESCRIPTION": "This app uses your location for geofencing.",
+        "NS_LOCATION_ALWAYS_AND_WHEN_IN_USE_USAGE_DESCRIPTION": "This app uses your location for geofencing.",
+        "NS_LOCATION_ALWAYS_USAGE_DESCRIPTION": "This app uses your location for geofencing."
+      }
     },
     "platforms": [
       "ios",
@@ -19,6 +23,6 @@
   "devDependencies": {
     "@radarlabs/cordova-plugin-radar": "file:../plugin",
     "cordova-android": "^11.0.0",
-    "cordova-ios": "^6.2.0"
+    "cordova-ios": "^6.3.0"
   }
 }

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@radarlabs/cordova-plugin-radar",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@radarlabs/cordova-plugin-radar",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "babel-eslint": "^10.0.1",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -3,7 +3,7 @@
   "description": "Cordova plugin for Radar, the leading geofencing and location tracking platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "main": "www/Radar.js",
   "devDependencies": {
     "babel-eslint": "^10.0.1",

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
         id="cordova-plugin-radar"
-        version="3.5.0">
+        version="3.5.1">
     <name>Radar</name>
     <js-module src="www/Radar.js" name="Radar">
         <clobbers target="cordova.plugins.radar"/>
@@ -54,6 +54,10 @@
 
         <header-file src="src/ios/CDVRadar.h"/>
         <source-file src="src/ios/CDVRadar.m"/>
-        <framework src="RadarSDK" type="podspec" spec="3.5.9"/>
+        <podspec>
+            <pods use-frameworks="true">
+                <pod name="RadarSDK" spec="3.5.9"/>
+            </pods>
+        </podspec>
     </platform>
 </plugin>

--- a/plugin/plugin.xml.template
+++ b/plugin/plugin.xml.template
@@ -54,6 +54,10 @@
 
         <header-file src="src/ios/CDVRadar.h"/>
         <source-file src="src/ios/CDVRadar.m"/>
-        <framework src="RadarSDK" type="podspec" spec="{{ version }}"/>
+        <podspec>
+            <pods use-frameworks="true">
+                <pod name="RadarSDK" spec="{{ version }}"/>
+            </pods>
+        </podspec>
     </platform>
 </plugin>


### PR DESCRIPTION
Installing Radar to a Cordova app via cordova plugin add results in the app's Podfile being overwritten, instead of just adding Radar 3.5.9 to the Podfile.

## Linear
https://linear.app/radarlabs/issue/FENCE-1347/installing-the-radar-cordova-sdk-results-in-the-apps-podfile-being